### PR TITLE
ci: align PR and merge workflows with notifynl-api

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -2,74 +2,23 @@ name: Merge
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - develop
+      - main
 
 concurrency:
   group: ${{ github.workflow }}.${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   IMAGE: ghcr.io/worth-nl/document-download-api
 
 jobs:
-  build-tag-test:
+  release:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        python-version: ["3.13"]
-        dockerfile-target: ["test"]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: gerlero/apt-install@v1
-        with:
-          packages: build-essential git libcurl4-openssl-dev curl libssl-dev
-          install-recommends: false
-
-      - uses: astral-sh/setup-uv@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-          activate-environment: true
-          enable-cache: true
-          cache-dependency-glob: |
-            requirements_nl_test.in
-            requirements_nl_test.txt
-
-      - name: Install application requirements (pip)
-        run: uv pip install -r requirements_nl_test.txt
-
-      - name: Set tag
-        id: set-tag
-        run: |
-          TAG=$(date +%Y%m%d).${{ github.run_number }}
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-
-      - uses: docker/login-action@v3
-        with:
-          registry: https://ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/setup-qemu-action@v3
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/build-push-action@v6
-        with:
-          file: docker/Dockerfile
-          load: true
-          tags: ${{ env.IMAGE }}:${{ steps.set-tag.outputs.tag }}
-          target: ${{ matrix.dockerfile-target }}
-
-    outputs:
-      tag: ${{ steps.set-tag.outputs.tag }}
-
-  image-push-and-release:
-    runs-on: ubuntu-latest
-
-    needs: build-tag-test
 
     permissions:
       contents: read
@@ -86,17 +35,29 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
+      - name: Set tag
+        id: set-tag
+        run: |
+          if [ "${{ github.ref_name }}" == "develop" ]; then
+            TAG=$(date +%Y%m%d).${{ github.run_number }}-dev
+          else
+            TAG=$(date +%Y%m%d).${{ github.run_number }}
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
       - uses: docker/build-push-action@v6
         with:
           file: docker/Dockerfile_nl
           push: true
-          tags: ${{ env.IMAGE }}:latest,${{ env.IMAGE }}:${{ needs.build-tag-test.outputs.tag }}
-          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.IMAGE }}:${{ steps.set-tag.outputs.tag }}
+          platforms: linux/amd64
           provenance: false
 
-      - uses: softprops/action-gh-release@v2
+      - name: Release
+        if: github.ref_name == 'main'
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.build-tag-test.outputs.tag }}
+          tag_name: ${{ steps.set-tag.outputs.tag }}
           make_latest: true
           token: ${{ secrets.RELEASE_TOKEN }}
           generate_release_notes: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,23 +1,43 @@
-name: Test
+name: PR
 
 on:
   pull_request:
     branches:
-      - "main"
+      - develop
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}.${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
+env:
+  IMAGE: ghcr.io/worth-nl/document-download-api
+
 jobs:
-  test:
+  unit-test:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         python-version: ["3.13"]
 
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+
     steps:
+      - uses: szenius/set-timezone@v2.0
+        with:
+          timezoneLinux: "Europe/Amsterdam"
+
       - uses: actions/checkout@v4
 
       - uses: gerlero/apt-install@v1
@@ -31,18 +51,184 @@ jobs:
           activate-environment: true
           enable-cache: true
           cache-dependency-glob: |
-            requirements_nl_test.in
+            requirements_nl.txt
             requirements_nl_test.txt
 
       - name: Install application requirements (pip)
         run: uv pip install -r requirements_nl_test.txt
 
       - uses: astral-sh/ruff-action@v3
+        with:
+          version-file: requirements_nl_test.txt
 
       - name: Generate version file
         run: make generate-version-file
 
       - uses: pavelzw/pytest-action@v2
         with:
+          job-summary: false
           verbose: false
           emoji: false
+          custom-arguments: --junitxml=reports/pytest-unit.xml
+          custom-pytest: uv run pytest
+
+      - uses: dorny/test-reporter@v2
+        if: ${{ !cancelled() }}
+        with:
+          name: PyTest Tests
+          path: reports/pytest-*.xml
+          reporter: java-junit
+          only-summary: true
+          use-actions-summary: false
+          badge-title: PYTEST
+
+  docker-test:
+    runs-on: ubuntu-latest
+
+    needs: unit-test
+
+    strategy:
+      matrix:
+        python-version: ["3.13"]
+        dockerfile-target: ["test"]
+
+    steps:
+      - uses: szenius/set-timezone@v2.0
+        with:
+          timezoneLinux: "Europe/Amsterdam"
+
+      - uses: actions/checkout@v4
+
+      - uses: gerlero/apt-install@v1
+        with:
+          packages: build-essential git libcurl4-openssl-dev curl libssl-dev
+          install-recommends: false
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          activate-environment: true
+          enable-cache: true
+          cache-dependency-glob: |
+            requirements_nl.txt
+            requirements_nl_test.txt
+
+      - name: Install application requirements (pip)
+        run: uv pip install -r requirements_nl_test.txt
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          file: docker/Dockerfile_nl
+          load: true
+          tags: ${{ env.IMAGE }}:test-${{ matrix.dockerfile-target }}
+          platforms: linux/amd64
+          provenance: false
+          target: ${{ matrix.dockerfile-target }}
+
+  build:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    needs: docker-test
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set tag
+        id: set-tag
+        run: |
+          TAG=$(date +%Y%m%d).${{ github.run_number }}-pr
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - uses: docker/login-action@v3
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          file: docker/Dockerfile_nl
+          push: true
+          tags: ${{ env.IMAGE }}:${{ steps.set-tag.outputs.tag }}
+          platforms: linux/amd64
+          provenance: false
+
+    outputs:
+      tag: ${{ steps.set-tag.outputs.tag }}
+
+  deploy:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    needs: build
+
+    environment:
+      name: Test
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: Worth-NL/notifynl-charts-private
+          ref: main
+          token: ${{ secrets.RELEASE_TOKEN }}
+        name: Checkout Worth-NL/notifynl-charts-private
+
+      - uses: bwvolleyball/k8s-toolkit@v1.0.0
+        with:
+          config: ${{ secrets.K8S_CONFIG }}
+
+      - name: Helm chart dependency build
+        run: helm dependency build
+        working-directory: ${{ github.workspace }}/notifynl-full
+
+      - name: Deploy new tag
+        id: helm-deploy
+        run: |
+          set -x
+          helm upgrade --install notifynl notifynl-full/ \
+          -n ${{ vars.NAMESPACE }} \
+          --reuse-values \
+          --set apps.documentDownloadApi.image.tag=${{ needs.build.outputs.tag }} \
+          --wait \
+          --timeout 300s
+
+      - name: Comment on PR if deployment fails
+        if: failure() && steps.helm-deploy.outcome == 'failure' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                "❌ **Test environment deployment failed**",
+                "",
+                "- Environment: `Test`",
+                "- Image tag: `${{ needs.build.outputs.tag }}`",
+                "",
+                "Check the workflow logs for the Helm error output.",
+                "",
+                "Check the test env k8s state/logs.",
+                "",
+                "Check if the helm release needs a rollback.",
+                "",
+                "Most likely issues:",
+                "- Package visibility",
+                "- ghcr.io credentials expiration or change"
+              ].join("\n")
+            })

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+reports/
 
 # Translations
 *.mo


### PR DESCRIPTION
PR runs now validate the Docker image, publish a -pr tag and deploy it to Test; merge builds -dev on develop and releases only from main.

Both workflows build the NL Dockerfile throughout. Merge previously tested the upstream one but pushed the NL one, so CI never validated the image that shipped. Also drops the unused :latest tag and the arm64 build.